### PR TITLE
Limit the update_rate of the simulated kobuki controller

### DIFF
--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -171,6 +171,7 @@
 
 	  <gazebo>
 	    <plugin name="kobuki_controller" filename="libgazebo_ros_kobuki.so">
+	      <update_rate>20</update_rate>
 	      <publish_tf>1</publish_tf>
 	      <left_wheel_joint_name>wheel_left_joint</left_wheel_joint_name>
 	      <right_wheel_joint_name>wheel_right_joint</right_wheel_joint_name>


### PR DESCRIPTION
…to 20 Hz like the real Kobuki platform (at least for wheel odometry).

(follow-up on https://github.com/Intermodalics/kobuki_desktop/pull/1)