### PR TITLE
Add time_offset parameter to compensate transport delay

### DIFF
--- a/kobuki_node/include/kobuki_node/kobuki_ros.hpp
+++ b/kobuki_node/include/kobuki_node/kobuki_ros.hpp
@@ -100,6 +100,7 @@ private:
   Odometry odometry;
   bool cmd_vel_timed_out_; // stops warning spam when cmd_vel flags as timed out more than once in a row
   bool serial_timed_out_; // stops warning spam when serial connection timed out more than once in a row
+  ros::Duration time_offset_; // time offset applied to all published header stamps to compensate the transport delay
 
   /*********************
    ** Ros Comms

--- a/kobuki_node/include/kobuki_node/odometry.hpp
+++ b/kobuki_node/include/kobuki_node/odometry.hpp
@@ -56,6 +56,7 @@ private:
   ros::Time last_cmd_time;
   bool publish_tf;
   bool use_imu_heading;
+  ros::Duration time_offset_; // time offset applied to all published header stamps to compensate the transport delay
   tf::TransformBroadcaster odom_broadcaster;
   ros::Publisher odom_publisher;
 

--- a/kobuki_node/src/library/kobuki_ros.cpp
+++ b/kobuki_node/src/library/kobuki_ros.cpp
@@ -148,6 +148,8 @@ bool KobukiRos::init(ros::NodeHandle& nh, ros::NodeHandle& nh_pub)
     return false;
   }
 
+  time_offset_ = ros::Duration(nh.param("time_offset", 0.0));
+
   /*********************
    ** Joint States
    **********************/
@@ -347,4 +349,3 @@ void KobukiRos::subscribeTopics(ros::NodeHandle& nh)
 
 
 } // namespace kobuki
-

--- a/kobuki_node/src/library/odometry.cpp
+++ b/kobuki_node/src/library/odometry.cpp
@@ -36,6 +36,9 @@ void Odometry::init(ros::NodeHandle& nh, const std::string& name) {
   cmd_vel_timeout.fromSec(timeout);
   ROS_INFO_STREAM("Kobuki : Velocity commands timeout: " << cmd_vel_timeout << " seconds [" << name << "].");
 
+  time_offset_ = ros::Duration(nh.param("time_offset", 0.0));
+  ROS_INFO_STREAM("Kobuki : Time offset: " << time_offset_.toSec() << " seconds [" << name << "].");
+
   if (!nh.getParam("odom_frame", odom_frame)) {
     ROS_WARN_STREAM("Kobuki : no param server setting for odom_frame, using default [" << odom_frame << "][" << name << "].");
   } else {
@@ -112,7 +115,7 @@ void Odometry::publishTransform(const geometry_msgs::Quaternion &odom_quat)
   if (publish_tf == false)
     return;
 
-  odom_trans.header.stamp = ros::Time::now();
+  odom_trans.header.stamp = ros::Time::now() + time_offset_;
   odom_trans.transform.translation.x = pose.x();
   odom_trans.transform.translation.y = pose.y();
   odom_trans.transform.translation.z = 0.0;
@@ -127,7 +130,7 @@ void Odometry::publishOdometry(const geometry_msgs::Quaternion &odom_quat,
   nav_msgs::OdometryPtr odom(new nav_msgs::Odometry);
 
   // Header
-  odom->header.stamp = ros::Time::now();
+  odom->header.stamp = ros::Time::now() + time_offset_;
   odom->header.frame_id = odom_frame;
   odom->child_frame_id = base_frame;
 

--- a/kobuki_node/src/library/slot_callbacks.cpp
+++ b/kobuki_node/src/library/slot_callbacks.cpp
@@ -64,7 +64,7 @@ void KobukiRos::publishSensorState()
     if (sensor_state_publisher.getNumSubscribers() > 0) {
       kobuki_msgs::SensorState state;
       CoreSensors::Data data = kobuki.getCoreSensorData();
-      state.header.stamp = ros::Time::now();
+      state.header.stamp = ros::Time::now() + time_offset_;
       state.time_stamp = data.time_stamp; // firmware time stamp
       state.bumper = data.bumper;
       state.wheel_drop = data.wheel_drop;
@@ -109,7 +109,7 @@ void KobukiRos::publishWheelState()
 
   if (ros::ok())
   {
-    joint_states.header.stamp = ros::Time::now();
+    joint_states.header.stamp = ros::Time::now() + time_offset_;
     joint_state_publisher.publish(joint_states);
   }
 }
@@ -124,7 +124,7 @@ void KobukiRos::publishInertia()
       sensor_msgs::ImuPtr msg(new sensor_msgs::Imu);
 
       msg->header.frame_id = "gyro_link";
-      msg->header.stamp = ros::Time::now();
+      msg->header.stamp = ros::Time::now() + time_offset_;
 
       msg->orientation = tf::createQuaternionMsgFromRollPitchYaw(0.0, 0.0, kobuki.getHeading());
 
@@ -157,7 +157,7 @@ void KobukiRos::publishRawInertia()
     sensor_msgs::ImuPtr msg(new sensor_msgs::Imu);
     ThreeAxisGyro::Data data = kobuki.getRawInertiaData();
 
-    ros::Time now = ros::Time::now();
+    ros::Time now = ros::Time::now() + time_offset_;
     ros::Duration interval(0.01); // Time interval between each sensor reading.
     const double digit_to_dps = 0.00875; // digit to deg/s ratio, comes from datasheet of 3d gyro[L3G4200D].
     unsigned int length = data.followed_data_length/3;
@@ -193,7 +193,7 @@ void KobukiRos::publishDockIRData()
       kobuki_msgs::DockInfraRedPtr msg(new kobuki_msgs::DockInfraRed);
 
       msg->header.frame_id = "dock_ir_link";
-      msg->header.stamp = ros::Time::now();
+      msg->header.stamp = ros::Time::now() + time_offset_;
 
       msg->data.push_back( data.docking[0] );
       msg->data.push_back( data.docking[1] );


### PR DESCRIPTION
The `kobuki_node` assigns time stamps using `ros::Time::now()` at the time the messages are published. There is no more accurate time sync mechanism. The `time_offset` parameter can be used to compensate that, under the assumption that all inputs have the same transport delay between the actual measurement and the publication.

`time_offset` must always be lower or equal to 0.